### PR TITLE
Fix dark mode toggle selector

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,7 +13,7 @@ document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
 const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 if (prefersDark) document.documentElement.classList.add('dark');
 
-document.getElementById('toggle-dark')?.addEventListener('click', () => {
+document.getElementById('theme-toggle')?.addEventListener('click', () => {
   document.documentElement.classList.toggle('dark');
 });
 


### PR DESCRIPTION
## Summary
- update `script.js` to use `theme-toggle` element for dark mode switching

## Testing
- `node test_toggle.js` *(verifies that clicking the checkbox toggles dark mode)*

------
https://chatgpt.com/codex/tasks/task_e_6844ca108c488328b93cf866f70b23ee