### PR TITLE
Add Jest setup and theme toggle test

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,18 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+coverage/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "yunoxia-site",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,27 @@
+beforeEach(() => {
+  document.body.innerHTML = '<main></main><input id="theme-toggle" type="checkbox">';
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }))
+  });
+  localStorage.clear();
+  jest.resetModules();
+  require('../assets/js/app.js');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+});
+
+test('toggling theme adds dark class and persists value', () => {
+  const checkbox = document.getElementById('theme-toggle');
+  checkbox.checked = true;
+  checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+  expect(document.documentElement.classList.contains('dark')).toBe(true);
+  expect(localStorage.getItem('theme')).toBe('dark');
+});


### PR DESCRIPTION
## Summary
- add package.json with Jest and jsdom
- ignore node_modules and coverage directories
- test theme toggle with jsdom
- run tests in CI

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ca12cb6883288e5f2a4b7c1fad1f