### PR TITLE
Fix fade-in visibility without JS

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html class="no-js" lang="ja">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -123,6 +123,11 @@ body {
   background-color: #ccc;
 }
 
+.no-js .fade-in {
+  opacity: 1;
+  transform: none;
+}
+
 .fade-in {
   opacity: 0;
   transform: translateY(10px);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,4 +1,5 @@
 document.addEventListener("DOMContentLoaded", () => {
+  document.documentElement.classList.remove("no-js");
   const container = document.querySelector("main");
 
   const themeToggleHandler = (e) => {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html class="no-js" lang="ja">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/links.html
+++ b/links.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html class="no-js" lang="ja">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/log.html
+++ b/log.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html class="no-js" lang="ja">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/works.html
+++ b/works.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html class="no-js" lang="ja">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Summary
- keep content visible when JS is disabled by adding `no-js` class
- remove that class once JS loads

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6845ad5bac988328a239e0c9a033e885