### PR TITLE
Add scroll reset and title update after PJAX loads

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -72,6 +72,8 @@ document.addEventListener("DOMContentLoaded", () => {
       const newContent = doc.querySelector("main").innerHTML;
 
       container.innerHTML = newContent;
+      document.title = doc.title;
+      window.scrollTo({ top: 0, left: 0 });
       if (push) window.history.pushState(null, "", url);
 
       reinitScripts();


### PR DESCRIPTION
## Summary
- update PJAX `loadContent` to update `document.title` and scroll to the top after page swap

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a6f6b6a0483289164a11f31473857