### PR TITLE
Add IntersectionObserver fallback

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -36,6 +36,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const initObserver = () => {
     if (observer) observer.disconnect();
+    if (!("IntersectionObserver" in window)) {
+      container
+        .querySelectorAll(".fade-in")
+        .forEach((el) => el.classList.add("visible"));
+      return;
+    }
     observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {


### PR DESCRIPTION
## Summary
- gracefully handle browsers that lack IntersectionObserver by directly adding `visible`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ad6c404f48328b8d010a4b121a62c