### PR TITLE
Add basic navigation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,19 @@ Because it is entirely static, the site can be deployed to any static hosting pr
 - A dark‑mode toggle (`theme-switch` element) remembers the user's preference and respects the system color scheme.
 - PJAX navigation in `assets/js/app.js` fetches page fragments and updates the history so navigation feels instant without full page reloads.
 
+## Running tests
+
+Install development dependencies:
+
+```bash
+npm install
+```
+
+Then execute:
+
+```bash
+npm test
+```
+
+The command launches a headless browser using Puppeteer and runs the Mocha/Chai suite defined in `tests/`.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "yunoxia-site",
+  "version": "1.0.0",
+  "description": "This repository contains the files that make up **yunoxia.one**, a small personal website. The pages are plain HTML styled with CSS and enhanced with a little JavaScript.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node tests/run-headless.js"
+  },
+  "devDependencies": {
+    "chai": "^4.4.1",
+    "mocha": "^10.2.0",
+    "puppeteer": "^22.4.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/navigation.test.js
+++ b/tests/navigation.test.js
@@ -1,0 +1,40 @@
+describe('Navigation', function() {
+  this.timeout(5000);
+  let frame;
+  let doc;
+
+  before(function(done) {
+    frame = document.getElementById('app');
+    frame.addEventListener('load', function onload() {
+      frame.removeEventListener('load', onload);
+      doc = frame.contentDocument;
+      // slight delay for scripts to initialize
+      setTimeout(done, 100);
+    });
+  });
+
+  function getHeading() {
+    return doc.querySelector('main h2').textContent.trim();
+  }
+
+  it('replaces <main> content for each link', function(done) {
+    const expected = ['Home', 'About', 'Works', 'Log', 'Links'];
+    const links = doc.querySelectorAll('nav a');
+    const seen = [getHeading()];
+    let i = 1;
+    function clickNext() {
+      if (i >= expected.length) {
+        expect(seen).to.eql(expected);
+        done();
+        return;
+      }
+      links[i].click();
+      setTimeout(() => {
+        seen.push(getHeading());
+        i++;
+        clickNext();
+      }, 200);
+    }
+    clickNext();
+  });
+});

--- a/tests/run-headless.js
+++ b/tests/run-headless.js
@@ -1,0 +1,14 @@
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({ headless: 'new' });
+  const page = await browser.newPage();
+  const url = 'file://' + path.join(__dirname, 'runner.html');
+  await page.goto(url);
+  const failures = await page.evaluate(() => new Promise(resolve => {
+    mocha.run(resolve);
+  }));
+  await browser.close();
+  process.exit(failures ? 1 : 0);
+})();

--- a/tests/runner.html
+++ b/tests/runner.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Site Tests</title>
+  <link rel="stylesheet" href="../node_modules/mocha/mocha.css">
+</head>
+<body>
+  <div id="mocha"></div>
+  <iframe id="app" src="../index.html" style="width:0;height:0;border:0;"></iframe>
+  <script src="../node_modules/mocha/mocha.js"></script>
+  <script src="../node_modules/chai/chai.js"></script>
+  <script>mocha.setup('bdd'); const { expect } = chai;</script>
+  <script src="navigation.test.js"></script>
+  <script>
+    mocha.run();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce Mocha/Chai-based test harness
- implement navigation test and headless runner
- document test usage in README

## Testing
- `npm test` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_684c1f045bd48328aa0e84a98215965d