### PR TITLE
Fix PJAX link handler for older browsers

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -121,6 +121,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const initLinks = () => {
     if (linkHandler) document.removeEventListener("click", linkHandler);
     linkHandler = (e) => {
+      if (!e.target.closest) return; // Older browsers
       const link = e.target.closest("a:not([target]):not([href^='#'])");
       if (!link) return;
       e.preventDefault();


### PR DESCRIPTION
## Summary
- guard against missing `closest()` when handling PJAX links

## Testing
- `npx puppeteer --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684c1fd610288328924117dcae97b319