### PR TITLE
Limit console errors when fetch fails

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,6 +4,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const container = document.querySelector("main");
   let observer;
   let linkHandler;
+  // Enable verbose logging by setting `localStorage.debug` to "true"
+  const debug = localStorage.getItem("debug") === "true";
 
   if (typeof gsap !== "undefined" && typeof ScrollTrigger !== "undefined") {
     gsap.registerPlugin(ScrollTrigger);
@@ -113,7 +115,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
       reinitScripts();
       initLinks();
-    } catch {
+    } catch (err) {
+      if (debug) console.error("loadContent fetch failed", err);
       window.location.href = url;
     }
   };


### PR DESCRIPTION
## Summary
- add a localStorage-based debug flag
- only log fetch errors in `loadContent` when debugging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c1fdd0abc8328878115fd7d87fcd5