### PR TITLE
Refactor HTML with reusable partials

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,25 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Outfit:wght@200;400;700&display=swap" rel="stylesheet" />
 </head>
 <body>
-  <label class="theme-switch">
-    <input type="checkbox" id="theme-toggle" />
-    <span class="slider">
-      <span class="icon sun"></span>
-      <span class="icon moon"></span>
-    </span>
-  </label>
-  <h1 class="logo">Yunoxia</h1>
-  <header>
-    <nav>
-      <ul class="nav">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="works.html">Works</a></li>
-        <li><a href="log.html">Log</a></li>
-        <li><a href="links.html">Links</a></li>
-      </ul>
-    </nav>
-  </header>
+  <header data-include="partials/header.html"></header>
   <main id="pjax-container">
     <section class="page fade-in">
       <h2>About</h2>
@@ -61,9 +43,7 @@
         この場所に残していく。</p>
     </section>
   </main>
-  <footer>
-    <p class="credit">© 2025 ゆー / yunoxia.one</p>
-  </footer>
+  <footer data-include="partials/footer.html"></footer>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/ScrollTrigger.min.js"></script>
   <script src="assets/js/app.js" defer></script>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,13 +1,30 @@
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
   const root = document.documentElement;
   root.classList.remove("no-js");
-  const container = document.querySelector("main");
+  let container;
   let observer;
   let linkHandler;
+
+  const loadPartials = async () => {
+    const includes = document.querySelectorAll("[data-include]");
+    for (const el of includes) {
+      try {
+        const res = await fetch(el.getAttribute("data-include"));
+        if (res.ok) {
+          el.outerHTML = await res.text();
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+  };
 
   if (typeof gsap !== "undefined" && typeof ScrollTrigger !== "undefined") {
     gsap.registerPlugin(ScrollTrigger);
   }
+
+  await loadPartials();
+  container = document.querySelector("main");
 
   const themeToggleHandler = (e) => {
     const dark = e.target.checked;

--- a/index.html
+++ b/index.html
@@ -10,34 +10,14 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Outfit:wght@200;400;700&display=swap" rel="stylesheet" />
 </head>
 <body>
-  <label class="theme-switch">
-    <input type="checkbox" id="theme-toggle" />
-    <span class="slider">
-      <span class="icon sun"></span>
-      <span class="icon moon"></span>
-    </span>
-  </label>
-  <h1 class="logo">Yunoxia</h1>
-  <header>
-    <nav>
-      <ul class="nav">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="works.html">Works</a></li>
-        <li><a href="log.html">Log</a></li>
-        <li><a href="links.html">Links</a></li>
-      </ul>
-    </nav>
-  </header>
+  <header data-include="partials/header.html"></header>
   <main id="pjax-container">
     <section class="page fade-in">
       <h2>Home</h2>
       <p>Welcome to yunoxia.one</p>
     </section>
   </main>
-  <footer>
-    <p class="credit">© 2025 ゆー / yunoxia.one</p>
-  </footer>
+  <footer data-include="partials/footer.html"></footer>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/ScrollTrigger.min.js"></script>
   <script src="assets/js/app.js" defer></script>

--- a/links.html
+++ b/links.html
@@ -10,34 +10,14 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Outfit:wght@200;400;700&display=swap" rel="stylesheet" />
 </head>
 <body>
-  <label class="theme-switch">
-    <input type="checkbox" id="theme-toggle" />
-    <span class="slider">
-      <span class="icon sun"></span>
-      <span class="icon moon"></span>
-    </span>
-  </label>
-  <h1 class="logo">Yunoxia</h1>
-  <header>
-    <nav>
-      <ul class="nav">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="works.html">Works</a></li>
-        <li><a href="log.html">Log</a></li>
-        <li><a href="links.html">Links</a></li>
-      </ul>
-    </nav>
-  </header>
+  <header data-include="partials/header.html"></header>
   <main id="pjax-container">
     <section class="page fade-in">
       <h2>Links</h2>
       <p>外部リンク集</p>
     </section>
   </main>
-  <footer>
-    <p class="credit">© 2025 ゆー / yunoxia.one</p>
-  </footer>
+  <footer data-include="partials/footer.html"></footer>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/ScrollTrigger.min.js"></script>
   <script src="assets/js/app.js" defer></script>

--- a/log.html
+++ b/log.html
@@ -10,34 +10,14 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Outfit:wght@200;400;700&display=swap" rel="stylesheet" />
 </head>
 <body>
-  <label class="theme-switch">
-    <input type="checkbox" id="theme-toggle" />
-    <span class="slider">
-      <span class="icon sun"></span>
-      <span class="icon moon"></span>
-    </span>
-  </label>
-  <h1 class="logo">Yunoxia</h1>
-  <header>
-    <nav>
-      <ul class="nav">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="works.html">Works</a></li>
-        <li><a href="log.html">Log</a></li>
-        <li><a href="links.html">Links</a></li>
-      </ul>
-    </nav>
-  </header>
+  <header data-include="partials/header.html"></header>
   <main id="pjax-container">
     <section class="page fade-in">
       <h2>Log</h2>
       <p>開発ログや思考メモ</p>
     </section>
   </main>
-  <footer>
-    <p class="credit">© 2025 ゆー / yunoxia.one</p>
-  </footer>
+  <footer data-include="partials/footer.html"></footer>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/ScrollTrigger.min.js"></script>
   <script src="assets/js/app.js" defer></script>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,1 @@
+<p class="credit">© 2025 ゆー / yunoxia.one</p>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,17 @@
+<label class="theme-switch">
+  <input type="checkbox" id="theme-toggle" />
+  <span class="slider">
+    <span class="icon sun"></span>
+    <span class="icon moon"></span>
+  </span>
+</label>
+<h1 class="logo">Yunoxia</h1>
+<nav>
+  <ul class="nav">
+    <li><a href="index.html">Home</a></li>
+    <li><a href="about.html">About</a></li>
+    <li><a href="works.html">Works</a></li>
+    <li><a href="log.html">Log</a></li>
+    <li><a href="links.html">Links</a></li>
+  </ul>
+</nav>

--- a/works.html
+++ b/works.html
@@ -10,34 +10,14 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Outfit:wght@200;400;700&display=swap" rel="stylesheet" />
 </head>
 <body>
-  <label class="theme-switch">
-    <input type="checkbox" id="theme-toggle" />
-    <span class="slider">
-      <span class="icon sun"></span>
-      <span class="icon moon"></span>
-    </span>
-  </label>
-  <h1 class="logo">Yunoxia</h1>
-  <header>
-    <nav>
-      <ul class="nav">
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About</a></li>
-        <li><a href="works.html">Works</a></li>
-        <li><a href="log.html">Log</a></li>
-        <li><a href="links.html">Links</a></li>
-      </ul>
-    </nav>
-  </header>
+  <header data-include="partials/header.html"></header>
   <main id="pjax-container">
     <section class="page fade-in">
       <h2>Works</h2>
       <p>制作物の紹介</p>
     </section>
   </main>
-  <footer>
-    <p class="credit">© 2025 ゆー / yunoxia.one</p>
-  </footer>
+  <footer data-include="partials/footer.html"></footer>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/gsap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/gsap@3/dist/ScrollTrigger.min.js"></script>
   <script src="assets/js/app.js" defer></script>


### PR DESCRIPTION
## Summary
- create header and footer partials to remove markup duplication
- load header/footer dynamically via JS before initializing site
- update all pages to use the new partial system

## Testing
- `node --check assets/js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_684c24bb83b48328b7af27a630f89b10